### PR TITLE
Prevent 'tests' package from being installed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,10 @@ install_requires =
 project_urls =
     Source = https://github.com/selforthis/umlayer
 
+[options.packages.find]
+exclude =
+    tests
+
 [options.extras_require]
 test =
     unittest


### PR DESCRIPTION
When installing with `pip install`, setuptools installs *tests* package to `site-packages` along with the `umlayer` package. This package should be explicitly excluded when [custom discovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery) is used.

The alternative is to use [automatic discovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#automatic-discovery) by removing `packages = find:` line.